### PR TITLE
Fixes #5, IMG paths are kept the same upon conversion

### DIFF
--- a/src/downshow.js
+++ b/src/downshow.js
@@ -158,7 +158,7 @@
       else
         setContent(node, '');
     } else if (node.tagName === 'IMG') {
-      var src = node.src ? nltrim(node.src) : '', alt = node.alt ? nltrim(node.alt) : '', caption = node.title ? nltrim(node.title) : '';
+      var src = node.getAttribute('src') ? nltrim(node.getAttribute('src')) : '', alt = node.alt ? nltrim(node.alt) : '', caption = node.title ? nltrim(node.title) : '';
       if (src.length > 0)
         setContent(node, '![' + alt + '](' + src  + (caption ? ' "' + caption + '"' : '') + ')');
       else


### PR DESCRIPTION
- .src was always returning the absolute path, while getAttribute('src') returns the actual attribute value
