### PR TITLE
Exposing post parse trim regexes for configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
-  - 0.10
+  - 4.0.0
 before_script:
   - npm install -g grunt-cli

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "jshint": "~2.3.0"
   },
   "dependencies": {
-    "jsdom": "~0.5.0"
+    "jsdom": "^7.2.2"
   },
   "repository": {
     "type": "git",

--- a/src/downshow.js
+++ b/src/downshow.js
@@ -206,19 +206,34 @@
       }
     }
 
-    return getContent(root)
-      // remove empty lines between blockquotes
-      .replace(/(\n(?:> )+[^\n]*)\n+(\n(?:> )+)/g, "$1\n$2")
-      // remove empty blockquotes
-      .replace(/\n((?:> )+[ ]*\n)+/g, '\n\n')
+    return postParse(getContent(root), options);
+  }
+
+  function postParse(md, options) {
+    // remove empty lines between blockquotes
+    md = md.replace(/(\n(?:> )+[^\n]*)\n+(\n(?:> )+)/g, "$1\n$2");
+    // remove empty blockquotes
+    md = md.replace(/\n((?:> )+[ ]*\n)+/g, '\n\n');
+
+    if (!options || !options.skipRemoveExtraNewlines) {
       // remove extra newlines
-      .replace(/\n[ \t]*(?:\n[ \t]*)+\n/g,'\n\n')
+      md = md.replace(/\n[ \t]*(?:\n[ \t]*)+\n/g, '\n\n');
+    }
+
+    if (!options || !options.skipTrailingWhitespace) {
       // remove trailing whitespace
-      .replace(/\s\s*$/, '')
-      // convert lists to inline when not using paragraphs
-      .replace(/^([ \t]*(?:\d+\.|\+|\-)[^\n]*)\n\n+(?=[ \t]*(?:\d+\.|\+|\-|\*)[^\n]*)/gm, "$1\n")
+      md = md.replace(/\s\s*$/, '');
+    }
+
+    // convert lists to inline when not using paragraphs
+    md = md.replace(/^([ \t]*(?:\d+\.|\+|\-)[^\n]*)\n\n+(?=[ \t]*(?:\d+\.|\+|\-|\*)[^\n]*)/gm, "$1\n");
+
+    if (!options || !options.skipStartingNewlines) {
       // remove starting newlines
-      .replace(/^\n\n*/, '');
+      md = md.replace(/^\n\n*/, '');
+    }
+
+    return md;
   }
 
   // Export for use in server and client.

--- a/test/test.js
+++ b/test/test.js
@@ -227,3 +227,17 @@ describe("paragraphs", function () {
     expect(downshow("<p><b>1</b></p><p><b>2</b></p>")).to.equal("**1**\n\n**2**");
   });
 });
+
+describe("postparse", function() {
+  it("should skip removing extra newlines", function() {
+    expect(downshow("text\n\n\n\n\ntext", { skipRemoveExtraNewlines: true })).to.equal("text\n\n\n\n\ntext");
+  });
+
+  it("should skip removing trailing whitespace", function() {
+    expect(downshow("text  ", { skipTrailingWhitespace: true })).to.equal("text  ");
+  });
+
+  it("should skip removing starting Newlines", function() {
+    expect(downshow("\n\ntext", { skipStartingNewlines: true })).to.equal("\n\ntext");
+  });
+});


### PR DESCRIPTION
Hey @acornejo , I've ran into an issue when i need to recursively call downshow from within the nodeparser and I have no control over any post parsing whitespace trimming done.

The current changes are very naive as far as configuration goes and the option names definitively needs feedback and change.
